### PR TITLE
Change where the visualization is pushed.

### DIFF
--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -66,3 +66,4 @@ jobs:
       with:
         branch: gh-pages
         folder: ${{env.WORKING_DIR}}/_html
+        target-folder: benchmarks/_visualization

--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -66,4 +66,4 @@ jobs:
       with:
         branch: gh-pages
         folder: ${{env.WORKING_DIR}}/_html
-        target-folder: benchmarks/_visualization
+        target-folder: benchmarks

--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -61,9 +61,11 @@ jobs:
       run: |
         asv show
         asv publish
+    - name: Move the readme into the HTML directory.
+      run: |
+        cp ${{github.workspace}}/README.md ${{env.WORKING_DIR}}/_html/README.md
     - name: Deploy to Github pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: ${{env.WORKING_DIR}}/_html
-        target-folder: benchmarks

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -59,7 +59,7 @@
     "results_dir": "_results",
     // The directory (relative to the current directory) that the html tree
     // should be written to. If not provided, defaults to "html".
-    "html_dir": "_html",
+    "html_dir": "_html/benchmarks",
     // The number of characters to retain in the commit hashes.
     // "hash_length": 8,
     // `asv` will cache wheels of the recent builds in each


### PR DESCRIPTION
Change what we are pushing to the github pages. Store the benchmark data and the visualization files in a `_html/benchmarks` subdirectory. Move the readme into the `_html` directory so that we get the same to-level page.