### PR TITLE
Introduce a script that will retrieve the example data from Zenodo.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "xgboost>=1.7.3",
     "iminuit>=1.20.0",
     "light_curve>=0.8.1",
-    "requests"
+    "requests",
+    "pooch",
 ]
 
 [project.urls]
@@ -41,6 +42,7 @@ build_canonical = "resspect.scripts.build_canonical:main"
 build_time_domain_snpcc = "resspect.scripts.build_time_domain_snpcc:main"
 build_time_domain_plasticc = "resspect.scripts.build_time_domain_plasticc:main"
 calculate_cosmology_metric = "resspect.scripts.calculate_cosmology_metric:main"
+fetch_example_data = "resspect.scripts.fetch_example_data:fetch_example_data"
 fit_dataset = "resspect.scripts.fit_dataset:main"
 make_metrics_plots = "resspect.scripts.make_metrics_plots:main"
 run_loop = "resspect.scripts.run_loop:main"

--- a/src/resspect/scripts/fetch_example_data.py
+++ b/src/resspect/scripts/fetch_example_data.py
@@ -1,0 +1,43 @@
+import pooch
+import os
+from pathlib import Path
+
+# Create a Pooch object to handle the data fetching
+POOCH = pooch.create(
+    path=pooch.os_cache("resspect"),
+    base_url="doi:10.5281/zenodo.13883296",
+    registry={
+        "SIMGEN_PUBLIC_DES.tar.gz": "md5:3ed2c475512d8c8cf8a2b8907ed21ed0",
+    },
+)
+
+
+def fetch_example_data():
+    """Use Pooch to fetch the example data, unpack it, and create a symlink to
+    the data directory in the project's data folder.
+    """
+
+    unpacked_files = POOCH.fetch(
+        "SIMGEN_PUBLIC_DES.tar.gz",
+        processor=pooch.Untar(extract_dir="."),
+    )
+
+    # Get the parent directory of the unpacked files.
+    # Note that index 0 is the tar file itself.
+    original_directory = Path(unpacked_files[1]).resolve().parent
+    print(f"Data unpacked into directory: {original_directory}")
+
+    # Create the target directory path for symlinking
+    this_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    target_dir = (this_dir.parent.parent.parent / "data/SIMGEN_PUBLIC_DES")
+
+    # Create the symlink if it doesn't already exist
+    try:
+        os.symlink(original_directory, target_dir, target_is_directory=True)
+        print(f"Created symlink to unpacked data here: {target_dir}")
+    except FileExistsError:
+        print(f"Symlink already exists at {target_dir}")
+
+
+if __name__ == "__main__":
+    fetch_example_data()


### PR DESCRIPTION
This script can be run from the command line as `fetch_example_data`. It will use Pooch to retrieve the tar.gz file from Zenodo using the DOI, and place the file in `<default cache directory>/resspect`. 

Once downloaded, the tar file will be unpacked into `<default cache>/resspect/SIMGEN_PUBLIC_DES`. When unpacked, a symlink will be created in the packages data directory such that all existing scripts should continue to work as expected. 