### PR TITLE
Remove broken algorithm option

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -65,16 +65,18 @@ def peakmem_learn_loop(ml_model):
         metrics_file = str(Path(dir_name) / "metrics.csv")
         output_queried_file = str(Path(dir_name) / "queried.csv")
         learn_loop(
-            nloops=25,
-            features_method="malanchev",
-            classifier=ml_model,
-            strategy="RandomSampling",
-            path_to_features=features_file,
-            output_metrics_file=metrics_file,
-            output_queried_file=output_queried_file,
-            training="original",
-            batch=1,
-        )  
+            LoopConfiguration(
+                nloops=25,
+                features_method="malanchev",
+                classifier=ml_model,
+                strategy="RandomSampling",
+                path_to_features=features_file,
+                output_metrics_file=metrics_file,
+                output_queried_file=output_queried_file,
+                training="original",
+                batch=1,
+            )
+        )
 
 
 # Parameterize the ML models and strategies we benchmark.

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -65,18 +65,16 @@ def peakmem_learn_loop(ml_model):
         metrics_file = str(Path(dir_name) / "metrics.csv")
         output_queried_file = str(Path(dir_name) / "queried.csv")
         learn_loop(
-            LoopConfiguration(
-                nloops=25,
-                features_method="malanchev",
-                classifier=ml_model,
-                strategy="RandomSampling",
-                path_to_features=features_file,
-                output_metrics_file=metrics_file,
-                output_queried_file=output_queried_file,
-                training="original",
-                batch=1,
-            )
-        )
+            nloops=25,
+            features_method="malanchev",
+            classifier=ml_model,
+            strategy="RandomSampling",
+            path_to_features=features_file,
+            output_metrics_file=metrics_file,
+            output_queried_file=output_queried_file,
+            training="original",
+            batch=1,
+        )  
 
 
 # Parameterize the ML models and strategies we benchmark.

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -950,11 +950,12 @@ class DataBase:
             self.predicted_class,  self.classprob, self.classifier = \
                    random_forest(self.train_features, self.train_labels,
                                  self.pool_features, **kwargs)
-
         elif method == 'GradientBoostedTrees':
-            self.predicted_class,  self.classprob, self.classifier = \
-                gradient_boosted_trees(self.train_features, self.train_labels,
-                                       self.pool_features, **kwargs)
+            raise ValueError("GradientBoostedTrees is currently unimplemented.")
+            # TODO: Restore once GradientBoostedTrees is fixed.
+            # self.predicted_class,  self.classprob, self.classifier = \
+            #     gradient_boosted_trees(self.train_features, self.train_labels,
+            #                            self.pool_features, **kwargs)
         elif method == 'KNN':
             self.predicted_class,  self.classprob, self.classifier = \
                 knn(self.train_features, self.train_labels,
@@ -972,10 +973,10 @@ class DataBase:
                 nbg(self.train_features, self.train_labels,
                           self.pool_features, **kwargs)
         else:
-            raise ValueError("The only classifiers implemented are" +
-                              "'RandomForest', 'GradientBoostedTrees'," +
-                              "'KNN', 'MLP' and NB'." +
-                             "\n Feel free to add other options.")
+            raise ValueError(
+                "The only classifiers implemented are 'RandomForest', 'KNN', 'MLP', "
+                "'SVM' and 'NB'.\nFeel free to add other options."
+            )
 
         # estimate classification for validation sample
         self.validation_class = \
@@ -1213,10 +1214,10 @@ class DataBase:
             Budgets for 4m and 8m respectively. 
         strategy: str (optional)
             Strategy used to choose the most informative object.
-            Current implementation accepts 'UncSampling' and
+            Current implementation accepts 'UncSampling'
             'RandomSampling', 'UncSamplingEntropy',
             'UncSamplingLeastConfident', 'UncSamplingMargin',
-            'QBDMI', 'QBDEntropy', . Default is `UncSampling`.
+            'QBDMI', and 'QBDEntropy'. Default is `UncSampling`.
         screen: bool (optional)
             If true, display on screen information about the
             displacement in order and classificaion probability due to


### PR DESCRIPTION
The code for `gradient_boosted_trees()` is commented out with a note "we need to find a non-bugged version of xgboost". This PR removes it as an option so the code doesn't just crash.