### PR TITLE
Separate fitting from prediction in `ResspectClassifier`

### DIFF
--- a/src/resspect/classifiers.py
+++ b/src/resspect/classifiers.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.neighbors import KNeighborsClassifier
@@ -31,14 +32,14 @@ __all__ = [
     'svm',
     'nbg',
     'bootstrap_clf',
-    'ResspectClassifer',
+    'ResspectClassifier',
     'RandomForest',
     'CLASSIFIER_REGISTRY',
     ]
 
 CLASSIFIER_REGISTRY = {}
 
-class ResspectClassifer():
+class ResspectClassifier():
     """Base class that all built-in RESSPECT classifiers will inherit from."""
 
     def __init__(self, **kwargs):
@@ -99,50 +100,8 @@ class ResspectClassifer():
 
         return predictions, prob
 
-    def bootstrap(self, n_ensembles, train_features, train_labels, test_features):
-        """Create an ensemble of predictions by resampling the provided training
-        data. Define the ensemble size by specifying the value for `n_ensembles`.
 
-        Parameters
-        ----------
-        n_ensembles : int
-            The number of classifiers in the ensemble.
-        train_features : array-like
-            The features used for training, [n_samples, m_features].
-        train_labels : array-like
-            The training labels, [n_samples].
-        test_features : array-like
-            The features used for testing, [n_samples, m_features].
-
-        Returns
-        -------
-        tuple(predictions, prob, ensemble_probs, ensemble_clf)
-            The classes and probabilities for the test sample.
-        """
-
-        # Create an array to store the probability output of each member of the ensemble
-        n_test_data = test_features.shape[0]
-        n_labels = np.unique(train_labels).size
-        ensemble_probs = np.zeros(shape=(n_test_data, n_ensembles, n_labels))
-
-        classifier_list = list()
-        for i in range(self.n_ensembles):
-            x_train, y_train = resample(train_features, train_labels)
-
-            self.fit(x_train, y_train)
-            _, class_prob = self.predict(test_features)
-
-            classifier_list.append((str(i), self.classifier))
-            ensemble_probs[:, i, :] = class_prob
-
-        ensemble_clf = PreFitVotingClassifier(classifier_list)
-        class_prob = ensemble_probs.mean(axis=1)
-        predictions = np.argmax(class_prob, axis=1)
-
-        return predictions, class_prob, ensemble_probs, ensemble_clf
-
-
-class RandomForest(ResspectClassifer):
+class RandomForest(ResspectClassifier):
     """RESSPECT-specific version of the sklearn RandomForestClassifier."""
 
     def __init__(self, **kwargs):
@@ -152,7 +111,7 @@ class RandomForest(ResspectClassifer):
         self.classifier = RandomForestClassifier(n_estimators=self.n_estimators, **self.kwargs)
 
 
-class KNN(ResspectClassifer):
+class KNN(ResspectClassifier):
     """RESSPECT-specific version of the sklearn KNeighborsClassifier."""
 
     def __init__(self, **kwargs):
@@ -161,7 +120,7 @@ class KNN(ResspectClassifer):
         self.classifier = KNeighborsClassifier(**self.kwargs)
 
 
-class MLP(ResspectClassifer):
+class MLP(ResspectClassifier):
     """RESSPECT-specific version of the sklearn MLPClassifier."""
 
     def __init__(self, **kwargs):
@@ -170,7 +129,7 @@ class MLP(ResspectClassifer):
         self.classifier = MLPClassifier(**self.kwargs)
 
 
-class SVM(ResspectClassifer):
+class SVM(ResspectClassifier):
     """RESSPECT-specific version of the sklearn SVC."""
 
     def __init__(self, **kwargs):
@@ -180,7 +139,7 @@ class SVM(ResspectClassifer):
         self.classifier = SVC(probability=self.probability, **self.kwargs)
 
 
-class NBG(ResspectClassifer):
+class NBG(ResspectClassifier):
     """RESSPECT-specific version of the sklearn GaussianNB."""
 
     def __init__(self, **kwargs):
@@ -189,17 +148,17 @@ class NBG(ResspectClassifer):
         self.classifier = GaussianNB(**self.kwargs)
 
 
-def bootstrap_clf(clf_function, n_ensembles, train_features,
+def bootstrap_clf(clf_class, n_ensembles, train_features,
                   train_labels, test_features, **kwargs):
     """
     Train an ensemble of classifiers using bootstrap.
 
     Parameters
     ----------
-    clf_function: function
-        function to train classifier
+    clf_class: ResspectClassifier
+        Classifier class to be used in the ensemble.
     n_ensembles: int
-        number of classifiers in the ensemble
+        number of classifiers in the ensemble.
     train_features: np.array
         Training sample features.
     train_labels: np.array
@@ -207,8 +166,7 @@ def bootstrap_clf(clf_function, n_ensembles, train_features,
     test_features: np.array
         Test sample features.
     kwargs: extra parameters
-        All keywords required by
-        sklearn.ensemble.RandomForestClassifier function.
+        All keywords required by the classifier class.
 
     Returns
     -------
@@ -218,26 +176,23 @@ def bootstrap_clf(clf_function, n_ensembles, train_features,
         Average distribution of ensemble members
     ensemble_probs: np.array
         Probability output of each member of the ensemble
+    ensemble_clf: PreFitVotingClassifier
+        Ensemble VotingClassifier instance
     """
     n_labels = np.unique(train_labels).size
-    num_test_data = test_features.shape[0]
-    ensemble_probs = np.zeros((num_test_data, n_ensembles, n_labels))
-    classifier_list = list()
+    n_test_data = test_features.shape[0]
+    ensemble_probs = np.zeros((n_test_data, n_ensembles, n_labels))
+    classifiers = list()
     for i in range(n_ensembles):
         x_train, y_train = resample(train_features, train_labels)
-        predicted_class, class_prob, clf = clf_function(x_train,
-                                                        y_train,
-                                                        test_features,
-                                                        **kwargs)
-        #clf = clf_function(**kwargs)
-        #clf.fit(x_train, y_train)
-        #predicted_class = clf.predict(test_features)
-        #class_prob = clf.predict_proba(test_features)
-        
-        classifier_list.append((str(i), clf))
+        clf = clf_class(**kwargs)
+        clf.fit(x_train, y_train)
+        _, class_prob = clf.predict(test_features)
+
+        classifiers.append(clf)
         ensemble_probs[:, i, :] = class_prob
 
-    ensemble_clf = PreFitVotingClassifier(classifier_list)
+    ensemble_clf = PreFitVotingClassifier(classifiers)
     class_prob = ensemble_probs.mean(axis=1)
     predictions = np.argmax(class_prob, axis=1)
     
@@ -416,8 +371,7 @@ def nbg(train_features: np.array, train_labels: np.array,
 class PreFitVotingClassifier(object):
     """Stripped-down version of VotingClassifier that uses prefit estimators"""
     def __init__(self, estimators, voting='soft', weights=None):
-        self.estimators = [e[1] for e in estimators]
-        self.named_estimators = dict(estimators)
+        self.estimators = estimators
         self.voting = voting
         self.weights = weights
 
@@ -452,7 +406,11 @@ class PreFitVotingClassifier(object):
 
     def _collect_probas(self, X):
         """Collect results from clf.predict calls. """
-        return np.asarray([clf.predict_proba(X) for clf in self.estimators])
+        results = []
+        for clf in self.estimators:
+            _, proba = clf.predict(X)
+            results.append(proba)
+        return np.asarray(results)
 
     def _predict_proba(self, X):
         """Predict class probabilities for X in 'soft' voting """
@@ -502,7 +460,11 @@ class PreFitVotingClassifier(object):
 
     def _predict(self, X):
         """Collect results from clf.predict calls. """
-        return np.asarray([clf.predict(X) for clf in self.estimators]).T
+        results = []
+        for clf in self.estimators:
+            predictions, _ = clf.predict(X)
+            results.append(predictions)
+        return np.asarray(results).T
 
 def main():
     return None

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -1007,25 +1007,20 @@ class DataBase:
         if clf_class is None:
             raise ValueError(f'Classifier, {method} not recognized!')
 
-        clf_instance = clf_class(**kwargs)
-
         # Fit an ensemble of classifiers and predict with all of them
         self.predicted_class, self.classprob, self.ensemble_probs, self.classifier = \
-            clf_instance.bootstrap(
+            bootstrap_clf(
+                clf_class,
                 n_ensembles,
                 self.train_features,
                 self.train_labels,
                 self.pool_features
             )
 
-        #! This probably won't work correctly for non-sklearn classifiers
-        #! See issue #50 https://github.com/LSSTDESC/RESSPECT/issues/50
         self.validation_class = \
             self.classifier.predict(self.validation_features)
         self.validation_prob = \
             self.classifier.predict_proba(self.validation_features)
-
-        
 
         if save_predictions:
             id_name = self.identify_keywords()


### PR DESCRIPTION
- Streamlined `RessepectClassifier` base class, no need to instantiate with training and test data.
- Move `bootstrap` outside of base class to support potential scenario of multiple types of classifiers in an ensemble.
- Implemented a simple `load_classifier` function. 
- Updated `database.py` to match the changes in `classifiers.py`.
- Changed `PreFitVotingClassifier` to work with classifier classes instead of free functions.
