### PR TITLE
Separate `ResspectClassifier.predict` into two methods

### DIFF
--- a/src/resspect/classifiers.py
+++ b/src/resspect/classifiers.py
@@ -100,6 +100,36 @@ class ResspectClassifier():
 
         return predictions, prob
 
+    def predict_class(self, test_features):
+        """Predict the class of the test sample using the trained classifier.
+
+        Parameters
+        ----------
+        test_features : array-like
+            The features used for testing, [n_samples, m_features].
+
+        Returns
+        -------
+        np.array
+            The predicted classes for the test sample. [n_samples]
+        """
+        return self.classifier.predict(test_features)
+
+
+    def predict_probabilities(self, test_features):
+        """Predict the probabilities of the test sample using the trained classifier.
+
+        Parameters
+        ----------
+        test_features : array-like
+            The features used for testing, [n_samples, m_features].
+
+        Returns
+        -------
+        np.array
+            The predicted probabilities for the test sample. [n_samples, m_classes]
+        """
+        return self.classifier.predict_proba(test_features)
 
 class RandomForest(ResspectClassifier):
     """RESSPECT-specific version of the sklearn RandomForestClassifier."""
@@ -187,7 +217,7 @@ def bootstrap_clf(clf_class, n_ensembles, train_features,
         x_train, y_train = resample(train_features, train_labels)
         clf = clf_class(**kwargs)
         clf.fit(x_train, y_train)
-        _, class_prob = clf.predict(test_features)
+        class_prob = clf.predict_probabilities(test_features)
 
         classifiers.append(clf)
         ensemble_probs[:, i, :] = class_prob

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -954,10 +954,11 @@ class DataBase:
 
         # Fit the classifier and predict with it
         clf_instance.fit(self.train_features, self.train_labels)
-        self.predicted_class, self.classprob = clf_instance.predict(self.pool_features)
+        self.classprob = clf_instance.predict_probabilities(self.pool_features)
 
         # estimate classification for validation sample
-        self.validation_class, self.validation_prob = clf_instance.predict(self.validation_features)
+        self.validation_class = clf_instance.predict_class(self.validation_features)
+        self.validation_prob = clf_instance.predict_probabilities(self.validation_features)
 
         if save_predictions:
             id_name = self.identify_keywords()


### PR DESCRIPTION
This PR breaks apart `ResspectClassifier.predict` into two methods 1) `predict_class` and 2) `predict_probabilities`. This avoids unnecessary duplication of calculations and will make the ResspectClassifier a bit more straightforward to subclass, especially for non-sklearn classifiers.
