### PR TITLE
Allow loading a pretrained classifier in `learn_loop`.

### DIFF
--- a/src/resspect/classifiers.py
+++ b/src/resspect/classifiers.py
@@ -15,8 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
+import pickle
 import numpy as np
+from pathlib import Path
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.neural_network import MLPClassifier
@@ -60,15 +61,23 @@ class ResspectClassifier():
 
         CLASSIFIER_REGISTRY[cls.__name__] = cls
 
-    def load_classifier(self, pretrained_classifier):
+    def load_classifier(self, pretrained_classifier_filepath):
         """Load a pretrained classifier.
 
         Parameters
         ----------
-        pretrained_classifier : object
-            A pretrained classifier instance.
+        pretrained_classifier_filepath : str
+            The filepath of a pickled, pretrained classifier instance.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the pretrained classifier pickle file does not exist.
         """
-        self.classifier = pretrained_classifier
+        if not Path(pretrained_classifier_filepath).is_file():
+            raise FileNotFoundError(f"File {pretrained_classifier_filepath} not found.")
+
+        self.classifier = pickle.load(pretrained_classifier_filepath)
 
     def fit(self, train_features, train_labels):
         """Fit the classifier to the training data.

--- a/src/resspect/classifiers.py
+++ b/src/resspect/classifiers.py
@@ -77,7 +77,8 @@ class ResspectClassifier():
         if not Path(pretrained_classifier_filepath).is_file():
             raise FileNotFoundError(f"File {pretrained_classifier_filepath} not found.")
 
-        self.classifier = pickle.load(pretrained_classifier_filepath)
+        with open(pretrained_classifier_filepath, 'rb') as f:
+            self.classifier = pickle.load(f)
 
     def fit(self, train_features, train_labels):
         """Fit the classifier to the training data.

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -914,7 +914,7 @@ class DataBase:
             wsample.close()
 
     def classify(self, method: str, save_predictions=False, pred_dir=None,
-                 loop=None, screen=False, **kwargs):
+                 loop=None, screen=False, pretrained_model_path=None, **kwargs):
         """Apply a machine learning classifier.
 
         Populate properties: predicted_class and class_prob
@@ -936,6 +936,8 @@ class DataBase:
         pred_dir: str (optional)
             Output directory to store class predictions.
             Only used if `save_predictions == True`. Default is None.
+        pretrained_model_path: str (optional)
+            Path to a pretrained model. Default is None.
         kwargs: extra parameters
             Parameters required by the chosen classifier.
         """
@@ -952,8 +954,13 @@ class DataBase:
 
         clf_instance = clf_class(**kwargs)
 
-        # Fit the classifier and predict with it
-        clf_instance.fit(self.train_features, self.train_labels)
+        # if a pretrained model is available, load it, otherwise fit the model
+        if pretrained_model_path is not None:
+            clf_instance.load(pretrained_model_path)
+        else:
+            clf_instance.fit(self.train_features, self.train_labels)
+
+        # estimate classification for pool sample
         self.classprob = clf_instance.predict_probabilities(self.pool_features)
 
         # estimate classification for validation sample

--- a/src/resspect/learn_loop.py
+++ b/src/resspect/learn_loop.py
@@ -107,6 +107,7 @@ def run_classification(
             pred_dir=config.pred_dir,
             loop=iteration_step,
             save_predictions=config.save_predictions,
+            pretrained_model_path=config.pretrained_model_path,
             **kwargs
         )
     return database_class

--- a/src/resspect/loop_configuration.py
+++ b/src/resspect/loop_configuration.py
@@ -87,6 +87,9 @@ class LoopConfiguration:
     initial_training_samples_file
         File name to save initial training samples.
         File will be saved if "training"!="original".
+    pretrained_model_path: str (optional)
+        Filepath to a pretrained model. If provided, the model will be loaded
+        and used to predict the queried samples.
     """
     nloops: int
     strategy: str
@@ -113,6 +116,7 @@ class LoopConfiguration:
     metadata_fname: str = None
     bar: bool = True
     initial_training_samples_file: str = None
+    pretrained_model_path: str = None
 
     def __post_init__(self):
         # file checking


### PR DESCRIPTION
Initial commit to add ability to pass a pretrained classifier pickle filepath to ResspectClassifier to use instead of training.

This PR adds a attribute to `LoopClassifier`, `pretrained_model_path` that will be used in `learn_loop` when calling `database.classify`. 

If the filepath is not None, we will attempt to unpickle and assign the result to the classifier in `ResspectClassifier`. Otherwise we raise a `FileNotFound` exception. 

Something similar will need to be done for `time_domain_loop`, but we'll wait on that until after the configuration dataclass has been implemented. 

