### PR TITLE
Pluggable query_strategies

### DIFF
--- a/src/resspect/time_domain_loop.py
+++ b/src/resspect/time_domain_loop.py
@@ -396,7 +396,7 @@ def _get_indices_of_objects_to_be_queried(
     else:
         object_indices = database_class.make_query(
             strategy=strategy, batch=batch, queryable=is_queryable,
-            query_thre=query_threshold)
+            query_threshold=query_threshold)
     return list(object_indices)
 
 

--- a/tests/resspect/test_plugin_utils.py
+++ b/tests/resspect/test_plugin_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from resspect.plugin_utils import import_module_from_string, fetch_classifier_class
+from resspect.plugin_utils import import_module_from_string, fetch_classifier_class, fetch_query_strategy_class
 
 
 def test_import_module_from_string():
@@ -66,3 +66,22 @@ def test_fetch_classifier_class_not_in_registry():
 
     assert "Error fetching class: Nonexistent" in str(excinfo.value)
 
+
+def test_fetch_query_strategy_class():
+    """Test the fetch_query_strategy_class function."""
+    requested_class = "builtins.BaseException"
+
+    returned_cls = fetch_query_strategy_class(requested_class)
+
+    assert returned_cls.__name__ == "BaseException"
+
+
+def test_fetch_query_strategy_class_not_in_registry():
+    """Test that an exception is raised when a model is requested that is not in the registry."""
+
+    requested_class = "Nonexistent"
+
+    with pytest.raises(ValueError) as excinfo:
+        fetch_query_strategy_class(requested_class)
+
+    assert "Error fetching class: Nonexistent" in str(excinfo.value)


### PR DESCRIPTION
This PR represents the work in implement pluggable query strategies. It is very similar is style to the pluggable classifier work. 

* A `QueryStrategy` class has been created
* Subclasses of `QueryStrategy` have been created for each of the 7 different built in strategies. 
* Machinery is in place to support and use query strategies that are defined in an external library.
* Updated tests