### PR TITLE
Fixing up Dockerfile, adding github action to build image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,32 @@
+
+name: Build Docker image
+# Shamelessly cribbed from https://docs.docker.com/build/ci/github-actions/test-before-push/
+# with minor modifications
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    
+env:
+  TEST_TAG: user/app:test
+  LATEST_TAG: user/app:latest
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: ${{ env.TEST_TAG }}
+          build-args: BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+
+        # TODO actually have this do something with test data
+      - name: Test
+        run: |
+          docker run --rm ${{ env.TEST_TAG }} -c "fit_dataset --help"

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ _html/
 .initialize_new_project.sh
 auxiliary_files/cosmo
 auxiliary_files/cosmo.hpp
+
+# Location for secrets used to log into TOM in a dev envornoment
+secrets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu
 
 ENV RESSPECT_DIR=/resspect
+
+# Note that this is where we copy resspect source at build time
+# and also where docker-compose mounts the curent source directory in this container.
 ENV RESSPECT_SRC=${RESSPECT_DIR}/resspect-src
 ENV RESSPECT_VENV=${RESSPECT_DIR}/resspect-venv
 ENV RESSPECT_VENV_BIN=${RESSPECT_VENV}/bin
@@ -8,9 +11,7 @@ ENV RESSPECT_WORK=${RESSPECT_DIR}/resspect-work
 
 WORKDIR ${RESSPECT_DIR}
 
-#ENV HOME=/
-
-RUN echo "entering resspect Dockerfile"
+RUN echo "Entering resspect Dockerfile"
 
 RUN apt-get update && \
    apt-get -y upgrade && \
@@ -20,7 +21,10 @@ RUN apt-get update && \
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-# Copy over resspect source from local checkout
+# Copy over resspect source from local checkout so we can install dependencies
+# and so the container will have a version of RESSPECT packaged when run standalone.
+#
+# If this line is changed, pleas refer to the bind mount in the compose file to ensure consistency.
 COPY . ${RESSPECT_SRC}
 
 # Create a venv for resspect

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,67 @@
 FROM ubuntu
 
-WORKDIR /resspect
-ENV HOME /
+ENV RESSPECT_DIR=/resspect
+ENV RESSPECT_SRC=${RESSPECT_DIR}/resspect-src
+ENV RESSPECT_VENV=${RESSPECT_DIR}/resspect-venv
+ENV RESSPECT_VENV_BIN=${RESSPECT_VENV}/bin
+ENV RESSPECT_WORK=${RESSPECT_DIR}/resspect-work
+
+WORKDIR ${RESSPECT_DIR}
+
+#ENV HOME=/
+
 RUN echo "entering resspect Dockerfile"
 
-RUN   apt-get update && \
+RUN apt-get update && \
    apt-get -y upgrade && \
    apt-get clean && \
-   apt-get install -y python3 python3-pip postgresql-client && \
+   apt-get install -y python3 python3-pip python3-venv postgresql-client git && \
    rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip install --upgrade pip
+# Copy over resspect source from local checkout
+COPY . ${RESSPECT_SRC}
 
-COPY pyproject.toml ./pyproject.toml
-RUN pip install dephell[full] && \
-    dephell deps convert --from=pyproject.toml --to=requirements.txt && \
-    pip install -r requirements.txt && \
-    pip uninstall -y dephell && \
-    rm -rf /root/.cache/pip
+# Create a venv for resspect
+RUN python3 -m venv ${RESSPECT_VENV}
 
+# Use this venv for future python commands in this dockerfile
+ENV PATH=${RESSPECT_VENV_BIN}:$PATH
+
+# Activate the venv every time we log in.
+RUN touch /root/.bashrc && echo "source ${RESSPECT_VENV_BIN}/activate" >> /root/.bashrc
+
+# Install RESSPECT and its dependencies within the virtual env.
+#
+# We inject a pretend version number via `git rev-parse HEAD` so that pip can find a version number for 
+# RESSPECT when this is built in github actions CI. Finding a version number depends deeply on available
+# git metadata in the local checkout.
+#
+# When called from docker/build-push-action, buildkit manages its own separate checkout of the 
+# container source rather than using the checkout supplied by the github actions runner.
+#
+# While the docker/build-push-action can be configured to retain the .git directory using 
+# `build-args: BUILDKIT_CONTEXT_KEEP_GIT_DIR=1` -- and we rely on that below --
+# docker/build-push-action cannot be configured to download tags.
+#
+# Sadly, pip uses setuptools_scm to generate a version number for our package. In turn
+# setuptools_scm relies on git-describe. git-describe relies on downloaded tags in the 
+# checkout to produce output which is processable by setuptools_scm, and therefore pip. 
+# These tags are simly not present when using docker/build-push-action.
+#
+# This approach has been adapted from the workaround in the setuptools_scm documentation here:
+# https://setuptools-scm.readthedocs.io/en/latest/usage/#with-dockerpodman
+#
+# It is probably not appropriate for publishing docker containers because it does not fall back
+# to the actual version number of the package during a release build.
+RUN bash -c "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_RESSPECT=0+$(cd ${RESSPECT_SRC} && git rev-parse HEAD) \
+             pip install ${RESSPECT_SRC}"
+
+# Create a sample work dir for resspect
+RUN mkdir -p ${RESSPECT_WORK}/results
+RUN mkdir -p ${RESSPECT_WORK}/plots
+RUN cp -r ${RESSPECT_SRC}/data ${RESSPECT_WORK}
 
 EXPOSE 8081
 ENTRYPOINT ["bash"]
-

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ Navigate to the repository folder and do
 
 You can now install this package with:  
 
-    (RESSPECT) >>> python setup.py install
+    (RESSPECT) >>> pip install -e .
 
 > You may choose to create your virtual environment within the folder of the repository. If you choose to do this, you must remember to exclude the virtual environment directory from version control using e.g., ``.gitignore``.   

--- a/README.md
+++ b/README.md
@@ -82,4 +82,54 @@ You can now install this package with:
 
     (RESSPECT) >>> pip install -e .
 
-> You may choose to create your virtual environment within the folder of the repository. If you choose to do this, you must remember to exclude the virtual environment directory from version control using e.g., ``.gitignore``.   
+> You may choose to create your virtual environment within the folder of the repository. If you choose to do this, you must remember to exclude the virtual environment directory from version control using e.g., ``.gitignore``.  
+
+# Starting the docker environment
+
+The docker file in this repository can be run as a standalone environment for testing or developing RESSPECT, or in connection with tom. You will need to start by installing Docker Desktop for your chosen platform before you start. 
+
+Note: These workflows have only been tested on macs; however the standalone docker image is built on Linux in in Github Actions CI.
+
+## Using standalone
+
+To use the container standalone first go into the root of the source directory, and build the container with:
+```
+docker build .
+```
+
+You can run the container two ways. The first way will use the version of resspect from your local checkout, which is probably what you want for development. After the
+container is built run:
+```
+docker run -it --rm --mount type=bind,source=.,target=/resspect/resspect-src resspect
+```
+
+This will put you into a bash shell in the container with the venv for resspect already activated, and the current version of resspect in your source checkout installed.
+
+If you wish to use the version of resspect packaged at build time, simply omit `--mount type=bind,source=.,target=/resspect/resspect-src` from the command above.
+
+## Using with tom docker-compose setup
+
+First checkout tom and follow [TOM's docker compose setup instructions](https://github.com/LSSTDESC/tom_desc?tab=readme-ov-file#deploying-a-dev-environment-with-docker). You will need to load [ELAsTiCC2 data](https://github.com/LSSTDESC/tom_desc?tab=readme-ov-file#for-elasticc2) into your tom environment in order to work with RESSPECT.
+
+When you have finished that setup, go into the top level source directory and run these two commands:
+```
+docker compose build
+docker compose up -d
+```
+
+You will now have a docker container called `resspect` which you can run resspect from. The version of resspect in use will be that of your local git checkout. That same docker container will be on the network with your tom setup, so you can access
+the tom docker container on port 8080.
+
+You can enter the `resspect` docker container to run commands with
+```
+docker compose run resspect
+```
+
+From the resspect container you should be able to log into the tom server with:
+```
+(resspect-venv) root@cd647ac7eca5:/resspect# python3
+Python 3.12.3 (main, Sep 11 2024, 14:17:37) [GCC 13.2.0] on linux
+Type "help", "copyright", "credits" or "license" for more information.
+>>> from resspect import tom_client as tc
+>>> tc = tc.TomClient(url="http://tom:8080", username='admin', password='<your tom password>')
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   resspect:
     tty: true
@@ -11,11 +9,13 @@ services:
       - "db"
     volumes:
       - type: bind
-        source: ./resspect
-        target: /resspect
+        source: ./
+        target: /resspect/resspect-src
       - type: bind
         source: ./secrets
         target: /secrets
+        bind:
+          create_host_path: true
     environment:
       - DB_USER=admin
       - DB_PASS=verysecurepassword
@@ -35,11 +35,17 @@ services:
       - POSTGRES_DB=resspectdb
       - POSTGRES_DATA_DIR=/docker-entrypoint-initdb.d
     volumes:
-      - ./resspectdb.sql:/docker-entrypoint-initdb.d/resspectdb.sql
       - type: bind
-        source: ./resspect
+        source: ./resspectdb.sql
+        target: /docker-entrypoint-initdb.d/resspectdb.sql
+      - type: bind
+        source: ./src/resspect
         target: /resspect
-
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d resspectdb"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
 
 networks:
   tom_desc_default:


### PR DESCRIPTION
- Image installs resspect from source
- Image builds on latest ubuntu avoiding conflicts with ubuntu's version of pip
- Image sets up a data directory and a venv for resspect
- Image works with the docker-compose file and the TOM docker-compose ecosystem.
- First time setup documentation included.