### PR TITLE
Removing erronious GNU GPL notifications from the source tree.

### DIFF
--- a/example_scripts/build_canonical_plasticc.py
+++ b/example_scripts/build_canonical_plasticc.py
@@ -3,11 +3,6 @@
 #
 # created on 29 January 2021
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/example_scripts/build_canonical_snpcc.py
+++ b/example_scripts/build_canonical_snpcc.py
@@ -3,12 +3,6 @@
 #
 # created on 31 December 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/__init__.py
+++ b/src/resspect/__init__.py
@@ -2,11 +2,6 @@
 # Author: Emille E. O. Ishida
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/resspect/batch_functions.py
+++ b/src/resspect/batch_functions.py
@@ -3,12 +3,6 @@
 #
 # created on 26 June 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/bazin.py
+++ b/src/resspect/bazin.py
@@ -4,12 +4,6 @@
 #
 # created on 25 January 2018
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/build_plasticc_canonical.py
+++ b/src/resspect/build_plasticc_canonical.py
@@ -3,12 +3,6 @@
 #
 # created on 30 December 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/build_plasticc_metadata.py
+++ b/src/resspect/build_plasticc_metadata.py
@@ -3,12 +3,6 @@
 #
 # created on 26 January 2021
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/build_snpcc_canonical.py
+++ b/src/resspect/build_snpcc_canonical.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/bump.py
+++ b/src/resspect/bump.py
@@ -3,12 +3,6 @@
 #    
 # created on 2 July 2022
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/classifiers.py
+++ b/src/resspect/classifiers.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/cosmo_metric_utils.py
+++ b/src/resspect/cosmo_metric_utils.py
@@ -3,12 +3,6 @@
 #
 # created on 23 March 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/exposure_time_calculator.py
+++ b/src/resspect/exposure_time_calculator.py
@@ -7,13 +7,6 @@
 # modified public DECam exposure time calculator by
 # CC F. Forster, J. Martinez, J.C. Maureira, 
 # https://github.com/fforster/HiTS-public
-# 
-#
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/resspect/feature_extractors/light_curve.py
+++ b/src/resspect/feature_extractors/light_curve.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/feature_extractors/malanchev.py
+++ b/src/resspect/feature_extractors/malanchev.py
@@ -3,12 +3,6 @@
 #
 # created on 9 April 2023
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/fit_lightcurves.py
+++ b/src/resspect/fit_lightcurves.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2022
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/learn_loop.py
+++ b/src/resspect/learn_loop.py
@@ -3,12 +3,6 @@
 #
 # created on 14 August 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/metrics.py
+++ b/src/resspect/metrics.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/plot_results.py
+++ b/src/resspect/plot_results.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/query_strategies.py
+++ b/src/resspect/query_strategies.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/read_dash.py
+++ b/src/resspect/read_dash.py
@@ -3,12 +3,6 @@
 #
 # created on 11 March 2024
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/salt3_utils.py
+++ b/src/resspect/salt3_utils.py
@@ -3,12 +3,6 @@
 #         
 # created on 30 March 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/samples_utils.py
+++ b/src/resspect/samples_utils.py
@@ -3,12 +3,6 @@
 #
 # created on 24 July 2023
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/__init__.py
+++ b/src/resspect/scripts/__init__.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/build_canonical.py
+++ b/src/resspect/scripts/build_canonical.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/build_time_domain_plasticc.py
+++ b/src/resspect/scripts/build_time_domain_plasticc.py
@@ -3,12 +3,6 @@
 #
 # created on 18 January 2022
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/build_time_domain_snpcc.py
+++ b/src/resspect/scripts/build_time_domain_snpcc.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/calculate_cosmology_metric.py
+++ b/src/resspect/scripts/calculate_cosmology_metric.py
@@ -3,12 +3,6 @@
 #
 # created on 21 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/fit_dataset.py
+++ b/src/resspect/scripts/fit_dataset.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/make_metrics_plots.py
+++ b/src/resspect/scripts/make_metrics_plots.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/run_loop.py
+++ b/src/resspect/scripts/run_loop.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/scripts/run_time_domain.py
+++ b/src/resspect/scripts/run_time_domain.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/snana_fits_to_pd.py
+++ b/src/resspect/snana_fits_to_pd.py
@@ -3,12 +3,6 @@
 #
 # created on 14 June 2019
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/time_domain_loop.py
+++ b/src/resspect/time_domain_loop.py
@@ -2,12 +2,6 @@
 # Author: Emille E. O. Ishida
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/time_domain_plasticc.py
+++ b/src/resspect/time_domain_plasticc.py
@@ -3,12 +3,6 @@
 #
 # created on 26 February 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/time_domain_snpcc.py
+++ b/src/resspect/time_domain_snpcc.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/tom_client.py
+++ b/src/resspect/tom_client.py
@@ -3,12 +3,6 @@
 #
 # created on 12 March 2024
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/resspect/update_stashes.py
+++ b/src/resspect/update_stashes.py
@@ -3,12 +3,6 @@
 #
 # created on 18 March 2024
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/resspect/test_database.py
+++ b/tests/resspect/test_database.py
@@ -3,12 +3,6 @@
 #
 # created on 30 March 2021
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/resspect/test_fit_lightcurves.py
+++ b/tests/resspect/test_fit_lightcurves.py
@@ -3,12 +3,6 @@
 #
 # created on 14 April 2020
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/resspect/test_metrics.py
+++ b/tests/resspect/test_metrics.py
@@ -3,12 +3,6 @@
 #
 # created on 12 March 2021
 #
-# Licensed GNU General Public License v3.0;
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gnu.org/licenses/gpl-3.0.en.html
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
- This was missed when the LICENSE file was changed to MIT
- Collecting information from Amanda, Emille, Rob, and Alex I believe the notices to be in error, and the entirety of this repository is MIT licensed from LSSTDESC at this time.

No more source code matches for GNU or GPL on this branch:
```
mtauraso@Michaels-MacBook-Pro RESSPECT % grep -rni gpl ./*
Binary file ./data/tests/RESSPECT_PHOTO.csv.gz matches
Binary file ./docs/images/active_learning_loop.png matches
mtauraso@Michaels-MacBook-Pro RESSPECT % grep -rni gnu ./*
```