### PR TITLE
Bazin feature names to upper case

### DIFF
--- a/src/resspect/feature_extractors/bazin.py
+++ b/src/resspect/feature_extractors/bazin.py
@@ -15,7 +15,7 @@ __all__ = ['BazinFeatureExtractor']
 class BazinFeatureExtractor(LightCurve):
     def __init__(self):
         super().__init__()
-        self.features_names = ['a', 'b', 't0', 'tfall', 'trise']
+        self.features_names = ['A', 'B', 't0', 'tfall', 'trise']
 
     def evaluate(self, time: np.array) -> dict:
         """


### PR DESCRIPTION
Converting the feature names to uppercase to match `fit_lightcurves.py:fit` (https://github.com/LSSTDESC/RESSPECT/blob/main/src/resspect/fit_lightcurves.py#L408)