### PR TITLE
Adding stub methods to LightCurve that child classes must implement.

### DIFF
--- a/src/resspect/feature_extractors/light_curve.py
+++ b/src/resspect/feature_extractors/light_curve.py
@@ -121,6 +121,28 @@ class LightCurve:
         self.sncode = 0
         self.sntype = ' '
 
+    def fit(self, band: str) -> np.ndarray:
+        """
+        Extract features for one filter.
+
+        Parameters
+        ----------
+        band: str
+            Choice of broad band filter
+
+        Returns
+        -------
+        np.ndarray
+        """
+        raise NotImplementedError()
+
+    def fit_all(self):
+        """
+        Performs feature extraction for all filters independently and concatenate results.
+        Populates self.features.
+        """
+        raise NotImplementedError()
+
     def _get_snpcc_photometry_raw_and_header(
             self, lc_data: np.ndarray,
             sntype_test_value: str = "-9") -> Tuple[np.ndarray, list]:


### PR DESCRIPTION
After conversation with @AmandaWasserman, these two methods seem to be the only two that are required to be implemented by the subclasses of `LightCurve`. 