### PR TITLE
Fixing classifier-related bugs

### DIFF
--- a/src/resspect/classifiers.py
+++ b/src/resspect/classifiers.py
@@ -147,7 +147,7 @@ class RandomForest(ResspectClassifier):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.n_estimators = kwargs.get('n_estimators', 100)
+        self.n_estimators = self.kwargs.pop('n_estimators', 100)
         self.classifier = RandomForestClassifier(n_estimators=self.n_estimators, **self.kwargs)
 
 
@@ -175,7 +175,7 @@ class SVM(ResspectClassifier):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.probability = kwargs.get('probability', True)
+        self.probability = self.kwargs.pop('probability', True)
         self.classifier = SVC(probability=self.probability, **self.kwargs)
 
 

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -950,7 +950,7 @@ class DataBase:
 
         # if a pretrained model is available, load it, otherwise fit the model
         if pretrained_model_path is not None:
-            clf_instance.load(pretrained_model_path)
+            clf_instance.load_classifier(pretrained_model_path)
         else:
             clf_instance.fit(self.train_features, self.train_labels)
 


### PR DESCRIPTION
Need to use `self.kwargs.pop(foo, bar)` in the classifier subclasses so that the key/values are removed from the kwargs dict, and not passed to the classifier instance twice. 

Also need to use the correct method name, `load_classifier` instead of `load` when using a ResspectClassifier subclass in `database.py`. 
