### PR TITLE
Updates to support end-to-end run with laiss-resspect classifier

### DIFF
--- a/src/resspect/__init__.py
+++ b/src/resspect/__init__.py
@@ -9,16 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VALID_STRATEGIES = [
-    "UncSampling",
-    "RandomSampling",
-    "UncSamplingEntropy",
-    "UncSamplingLeastConfident",
-    "UncSamplingMargin",
-    "QBDMI",
-    "QBDEntropy",
-]
-
 from .base_configuration import *
 from .bazin import *
 from .build_plasticc_canonical import *

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -454,6 +454,8 @@ class DataBase:
             id_name = 'id'
         elif 'objid' in self.metadata_names:
             id_name = 'objid'
+        elif 'objectid' in self.metadata_names:
+            id_name = 'objectid'
         else:
             logger.warning('No object identification found in metadata - using first column as object identification!')
             id_name = self.metadata_names[0]
@@ -1261,7 +1263,7 @@ class DataBase:
         nquery = len(q2)
 
         data_copy = self.pool_metadata.copy()
-        query_ids = [data_copy['id'].values[item] for item in query_indx]
+        query_ids = [data_copy['objectid'].values[item] for item in query_indx]
 
         while len(query_indx) > 0 and self.pool_metadata.shape[0] > 0:
 
@@ -1389,23 +1391,23 @@ class DataBase:
             raise ValueError('Wrong dimensionality for test/val samples.')
 
         for name in query_ids:
-            if name in self.pool_metadata['id'].values:
+            if name in self.pool_metadata['objectid'].values:
                 raise ValueError('Queried object ', name, ' is still in pool sample!')
 
-            if name not in self.train_metadata['id'].values:
+            if name not in self.train_metadata['objectid'].values:
                 raise ValueError('Queried object ', name, ' not in training!')
 
         # check if there are repeated ids
-        for name in self.train_metadata['id'].values:
-            if name in self.pool_metadata['id'].values:
+        for name in self.train_metadata['objectid'].values:
+            if name in self.pool_metadata['objectid'].values:
                 raise ValueError('After update! Object ', name,
                                  ' found in pool and training samples!')
 
-            if name in self.test_metadata['id'].values:
+            if name in self.test_metadata['objectid'].values:
                 raise ValueError('After update! Object ', name,
                                  ' found in test and training samples!')
 
-            if name in self.validation_metadata['id'].values:
+            if name in self.validation_metadata['objectid'].values:
                 raise ValueError('After update! Object ', name,
                                  ' found in validation and training samples!')
 

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -189,6 +189,8 @@ class DataBase:
         self.feature_extractor_class = None
         self.features = pd.DataFrame([])
         self.features_names = []
+        self.id_name = None
+        self.label_name = None
         self.metadata = pd.DataFrame()
         self.metadata_names = []
         self.metrics_list_names = []
@@ -449,18 +451,41 @@ class DataBase:
         id_name: str
             String of object identification.
         """
+        if self.id_name is None:
 
-        if 'id' in self.metadata_names:
-            id_name = 'id'
-        elif 'objid' in self.metadata_names:
-            id_name = 'objid'
-        elif 'objectid' in self.metadata_names:
-            id_name = 'objectid'
-        else:
-            logger.warning('No object identification found in metadata - using first column as object identification!')
-            id_name = self.metadata_names[0]
+            if self.feature_extractor_class:
+                self.id_name = self.feature_extractor_class.id_column
+            elif 'id' in self.metadata_names:
+                self.id_name = 'id'
+            elif 'objid' in self.metadata_names:
+                self.id_name = 'objid'
+            elif 'objectid' in self.metadata_names:
+                self.id_name = 'objectid'
+            else:
+                logger.warning('No object identification found in metadata - using first column as object identification!')
+                self.id_name = self.metadata_names[0]
 
-        return id_name
+        return self.id_name
+
+    def identfy_labels(self):
+        """Return the most logical column name for the data label column.
+        If self.label_name is already defined, this will pass through without
+        recalculating the label name.
+
+        Returns
+        -------
+        str
+            The string of the label column name.
+        """
+        if self.label_name is None:
+            if self.feature_extractor_class:
+                self.label_name = self.feature_extractor_class.label_column
+            elif 'type' in self.metadata_names:
+                self.label_name = 'type'
+            elif 'sntype' in self.metadata_names:
+                self.label_name = 'sntype'
+
+        return self.label_name
 
     def build_orig_samples(self, nclass=2, screen=False, queryable=False,
                            sep_files=False):
@@ -1263,7 +1288,7 @@ class DataBase:
         nquery = len(q2)
 
         data_copy = self.pool_metadata.copy()
-        query_ids = [data_copy['objectid'].values[item] for item in query_indx]
+        query_ids = [data_copy[id_name].values[item] for item in query_indx]
 
         while len(query_indx) > 0 and self.pool_metadata.shape[0] > 0:
 
@@ -1391,23 +1416,23 @@ class DataBase:
             raise ValueError('Wrong dimensionality for test/val samples.')
 
         for name in query_ids:
-            if name in self.pool_metadata['objectid'].values:
+            if name in self.pool_metadata[id_name].values:
                 raise ValueError('Queried object ', name, ' is still in pool sample!')
 
-            if name not in self.train_metadata['objectid'].values:
+            if name not in self.train_metadata[id_name].values:
                 raise ValueError('Queried object ', name, ' not in training!')
 
         # check if there are repeated ids
-        for name in self.train_metadata['objectid'].values:
-            if name in self.pool_metadata['objectid'].values:
+        for name in self.train_metadata[id_name].values:
+            if name in self.pool_metadata[id_name].values:
                 raise ValueError('After update! Object ', name,
                                  ' found in pool and training samples!')
 
-            if name in self.test_metadata['objectid'].values:
+            if name in self.test_metadata[id_name].values:
                 raise ValueError('After update! Object ', name,
                                  ' found in test and training samples!')
 
-            if name in self.validation_metadata['objectid'].values:
+            if name in self.validation_metadata[id_name].values:
                 raise ValueError('After update! Object ', name,
                                  ' found in validation and training samples!')
 

--- a/src/resspect/feature_handling_utils.py
+++ b/src/resspect/feature_handling_utils.py
@@ -33,7 +33,6 @@ def load_external_features(
                     data = pd.read_csv(io.BytesIO(content))
             else:
                 data = pd.read_csv(filename, index_col=False)
-                print(data.keys()[0])
                 if "Unnamed" not in data.keys()[0] and " " in data.keys()[0]:
                     data = pd.read_csv(filename, sep=' ', index_col=False)
         else:

--- a/src/resspect/fit_lightcurves.py
+++ b/src/resspect/fit_lightcurves.py
@@ -391,6 +391,7 @@ def request_TOM_data(url: str = "https://desc-tom-2.lbl.gov", username: str = No
         dic['mjd_now'] = mjdnow
     if cheat_gentypes is not None:
         dic['cheat_gentypes'] = cheat_gentypes
+    dic['include_hostinfo'] = True
     res = tom.post('elasticc2/gethottransients', json = dic)
     data_dic = res.json()
     return data_dic

--- a/src/resspect/loop_configuration.py
+++ b/src/resspect/loop_configuration.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from os import path
 
-from resspect import VALID_STRATEGIES, BaseConfiguration
+from resspect import BaseConfiguration
+from resspect.query_strategies import QUERY_STRATEGY_REGISTRY
 
 @dataclass
 class LoopConfiguration(BaseConfiguration):
@@ -148,7 +149,7 @@ class LoopConfiguration(BaseConfiguration):
                 raise ValueError("provided `pred_dir` does not exist/is not a directory.")
 
         # check strategy
-        if self.strategy not in VALID_STRATEGIES:
+        if self.strategy not in QUERY_STRATEGY_REGISTRY:
             raise ValueError(f"{self.strategy} is not a valid strategy.")
         if "QBD" in self.strategy and not self.classifier_bootstrap:
             raise ValueError("Bootstrap must be true when using disagreement strategy")

--- a/src/resspect/query_strategies.py
+++ b/src/resspect/query_strategies.py
@@ -9,7 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ['uncertainty_sampling',
+__all__ = ['certainty_sampling',
+           'uncertainty_sampling',
            'random_sampling',
            'uncertainty_sampling_entropy',
            'uncertainty_sampling_least_confident',
@@ -88,6 +89,42 @@ class QueryStrategy:
             Subclasses must implement this method.
         """
         raise NotImplementedError
+
+
+class CertaintySampling(QueryStrategy):
+    """RESSPECT-specific implementation of certainty sampling."""
+    def __init__(self,
+                 queryable_ids: np.array,
+                 test_ids: np.array,
+                 batch: int,
+                 query_threshold: float,
+                 screen: bool,
+                 **kwargs):
+        super().__init__(queryable_ids, test_ids, batch, query_threshold, screen, **kwargs)
+
+    def sample(self, probability: np.array) -> list:
+        """Search for the sample with highest anomaly certainty in predicted class.
+
+        Parameters
+        ----------
+        probability : np.array
+            Classification probability. One value per class per object.
+
+        Returns
+        -------
+        list
+            List of indexes identifying the objects from the test sample
+            to be queried in decreasing order of importance.
+            If there are less queryable objects than the required batch
+            it will return only the available objects -- so the list of
+            objects to query can be smaller than 'batch'.
+        """
+        return certainty_sampling(probability,
+                                  test_ids=self.test_ids,
+                                  queryable_ids=self.queryable_ids,
+                                  batch=self.batch,
+                                  screen=self.screen,
+                                  query_thre=self.query_threshold)
 
 
 class UncSampling(QueryStrategy):
@@ -368,6 +405,7 @@ class QBDEntropy(QueryStrategy):
                            screen=self.screen,
                            query_thre=self.query_threshold)
 
+
 def compute_entropy(ps: np.array):
     """
     Calcualte the entropy for discrete distributoons assuming the events are
@@ -409,6 +447,85 @@ def compute_qbd_mi_entropy(ensemble_probs: np.array):
     conditional_entropy = compute_entropy(ensemble_probs)
     mutual_information = entropy_avg_dist - np.mean(conditional_entropy, axis=1)
     return entropy_avg_dist, mutual_information
+
+
+def certainty_sampling(
+        class_prob: np.array,
+        test_ids: np.array,
+        queryable_ids: np.array,
+        batch=1,
+        screen=False,
+        query_thre=1.0
+    ) -> list:
+    """Search for the sample with highest anomaly certainty in predicted class.
+
+    Parameters
+    ----------
+    class_prob: np.array
+        Classification probability. One value per class per object.
+    test_ids: np.array
+        Set of ids for objects in the test sample.
+    queryable_ids: np.array
+        Set of ids for objects available for querying.
+    batch: int (optional)
+        Number of objects to be chosen in each batch query.
+        Default is 1.
+    screen: bool (optional)
+        If True display on screen the shift in index and
+        the difference in estimated probabilities of being Ia
+        caused by constraints on the sample available for querying.
+    query_thre: float (optional)
+        Maximum percentile where a spectra is considered worth it.
+        If not queryable object is available before this threshold,
+        return empty query. Default is 1.0.
+
+    Returns
+    -------
+    query_indx: list
+            List of indexes identifying the objects from the test sample
+            to be queried in decreasing order of importance.
+            If there are less queryable objects than the required batch
+            it will return only the available objects -- so the list of
+            objects to query can be smaller than 'batch'.
+    """
+
+    if class_prob.shape[0] != test_ids.shape[0]:
+        raise ValueError('Number of probabiblities is different ' +
+                         'from number of objects in the test sample!')
+
+    # calculate distance to the decision boundary - only binary classification
+    anomaly_value = 1.0 #! Change this to be the value of anomaly (1 or 0)
+    dist = abs(class_prob[:, 1] - anomaly_value)
+
+    # get indexes in increasing order
+    order = dist.argsort()
+
+    # only allow objects in the query sample to be chosen
+    flag = list(pd.Series(data=test_ids[order]).isin(queryable_ids))
+
+    # check if there are queryable objects within threshold
+    indx = int(len(flag) * query_thre)
+
+    if sum(flag[:indx]) > 0:
+
+        # arrange queryable elements in increasing order
+        flag = np.array(flag)
+        final_order = order[flag]
+
+        if screen:
+            print('\n Inside Certainty Sampling: ')
+            print('       query_ids: ', test_ids[final_order][:batch], '\n')
+            print('   number of test_ids: ', test_ids.shape[0])
+            print('   number of queryable_ids: ', len(queryable_ids), '\n')
+            print('   *** Displacement caused by constraints on query****')
+            print('   0 -> ', list(order).index(final_order[0]))
+            print('   ', class_prob[order[0]], '-- > ', class_prob[final_order[0]], '\n')
+
+        # return the index of the highest certainty objects which are queryable
+        return list(final_order)[:batch]
+
+    else:
+        return list([])
 
 
 def uncertainty_sampling(class_prob: np.array, test_ids: np.array,
@@ -621,6 +738,7 @@ def uncertainty_sampling_entropy(class_prob: np.array, test_ids: np.array,
     else:
         return list([])
 
+
 def uncertainty_sampling_least_confident(class_prob: np.array, test_ids: np.array,
                          queryable_ids: np.array, batch=1,
                          screen=False, query_thre=1.0) -> list:
@@ -686,6 +804,7 @@ def uncertainty_sampling_least_confident(class_prob: np.array, test_ids: np.arra
 
     else:
         return list([])
+
 
 def uncertainty_sampling_margin(class_prob: np.array, test_ids: np.array,
                          queryable_ids: np.array, batch=1,

--- a/src/resspect/time_domain_configuration.py
+++ b/src/resspect/time_domain_configuration.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from os import path
 
-from resspect import VALID_STRATEGIES, BaseConfiguration
+from resspect import BaseConfiguration
+from resspect.query_strategies import QUERY_STRATEGY_REGISTRY
 
 @dataclass
 class TimeDomainConfiguration(BaseConfiguration):
@@ -114,7 +115,7 @@ class TimeDomainConfiguration(BaseConfiguration):
             raise ValueError("`path_to_features` must be an existing directory.")
 
         # check strategy
-        if self.strategy not in VALID_STRATEGIES:
+        if self.strategy not in QUERY_STRATEGY_REGISTRY:
             raise ValueError(f"{self.strategy} is not a valid strategy.")
         if "QBD" in self.strategy and not self.clf_bootstrap:
             raise ValueError("Bootstrap must be true when using disagreement strategy")

--- a/src/resspect/time_domain_loop.py
+++ b/src/resspect/time_domain_loop.py
@@ -155,7 +155,6 @@ def _update_light_curve_data_val_and_test_data(
 
 def _update_data_by_remove_repeated_ids(first_loop_data: DataBase,
                                         light_curve_data: DataBase,
-                                        id_key_name: str,
                                         pool_labels_class: str = 'Ia') -> Tuple[
         DataBase, DataBase]:
     """
@@ -172,6 +171,8 @@ def _update_data_by_remove_repeated_ids(first_loop_data: DataBase,
     pool_labels_class
         pool labels class name
     """
+    id_key_name = first_loop_data.identify_keywords()
+    label_key_name = first_loop_data.identfy_labels()
     repeated_id_flags = np.in1d(
         first_loop_data.pool_metadata[id_key_name].values,
         light_curve_data.train_metadata[id_key_name].values)
@@ -180,16 +181,7 @@ def _update_data_by_remove_repeated_ids(first_loop_data: DataBase,
     first_loop_data.pool_features = first_loop_data.pool_features[
         ~repeated_id_flags]
     pool_labels = (
-
-
-        #! #############################################################
-        #! GREAT BIG WARNING - This MUST be fixed!!!
-        #! 'sntype' should be dynamically pulled from the feature_extractor.label
-        #! class attribute - NOT HARDCODED!!!!!!
-        #! #############################################################
-            first_loop_data.pool_metadata['sntype'].values == pool_labels_class)
-
-
+            first_loop_data.pool_metadata[label_key_name].values == pool_labels_class)
     first_loop_data.pool_labels = pool_labels.astype(int)
     light_curve_data.pool_features = first_loop_data.pool_features
     light_curve_data.pool_metadata = first_loop_data.pool_metadata
@@ -616,6 +608,8 @@ def _update_light_curve_data_for_next_epoch(
         If True, consider samples separately read
         from independent files. Default is False.
     """
+    id_key_name = light_curve_data.identify_keywords()
+
     light_curve_data.pool_metadata = next_day_data.pool_metadata
     light_curve_data.pool_features = next_day_data.pool_features
     light_curve_data.pool_labels = next_day_data.pool_labels
@@ -635,10 +629,10 @@ def _update_light_curve_data_for_next_epoch(
     if is_queryable:
         queryable_flag = light_curve_data.pool_metadata['queryable'].values
         light_curve_data.queryable_ids = light_curve_data.pool_metadata[
-            'objectid'].values[queryable_flag]
+            id_key_name].values[queryable_flag]
     else:
         light_curve_data.queryable_ids = light_curve_data.pool_metadata[
-            'objectid'].values
+            id_key_name].values
     return light_curve_data
 
 
@@ -835,7 +829,7 @@ def time_domain_loop(config, **kwargs):
     light_curve_train_ids = light_curve_data.train_metadata[id_key_name].values
 
     first_loop_data, light_curve_data = _update_data_by_remove_repeated_ids(
-        first_loop_data, light_curve_data, id_key_name
+        first_loop_data, light_curve_data
     )
     light_curve_data = _update_light_curve_data_val_and_test_data(
         light_curve_data,

--- a/src/resspect/time_domain_loop.py
+++ b/src/resspect/time_domain_loop.py
@@ -180,7 +180,16 @@ def _update_data_by_remove_repeated_ids(first_loop_data: DataBase,
     first_loop_data.pool_features = first_loop_data.pool_features[
         ~repeated_id_flags]
     pool_labels = (
-            first_loop_data.pool_metadata['type'].values == pool_labels_class)
+
+
+        #! #############################################################
+        #! GREAT BIG WARNING - This MUST be fixed!!!
+        #! 'sntype' should be dynamically pulled from the feature_extractor.label
+        #! class attribute - NOT HARDCODED!!!!!!
+        #! #############################################################
+            first_loop_data.pool_metadata['sntype'].values == pool_labels_class)
+
+
     first_loop_data.pool_labels = pool_labels.astype(int)
     light_curve_data.pool_features = first_loop_data.pool_features
     light_curve_data.pool_metadata = first_loop_data.pool_metadata

--- a/src/resspect/time_domain_loop.py
+++ b/src/resspect/time_domain_loop.py
@@ -635,10 +635,10 @@ def _update_light_curve_data_for_next_epoch(
     if is_queryable:
         queryable_flag = light_curve_data.pool_metadata['queryable'].values
         light_curve_data.queryable_ids = light_curve_data.pool_metadata[
-            'id'].values[queryable_flag]
+            'objectid'].values[queryable_flag]
     else:
         light_curve_data.queryable_ids = light_curve_data.pool_metadata[
-            'id'].values
+            'objectid'].values
     return light_curve_data
 
 

--- a/tests/resspect/test_query_strategies.py
+++ b/tests/resspect/test_query_strategies.py
@@ -8,6 +8,7 @@ from resspect.query_strategies import (
     qbd_entropy,
     qbd_mi,
     random_sampling,
+    certainty_sampling,
     uncertainty_sampling,
     uncertainty_sampling_entropy,
     uncertainty_sampling_least_confident,
@@ -29,6 +30,30 @@ def test_random_sampling(batch_size, queryable):
     if queryable:
         assert np.all(np.array(sample) % 3 == 0)
 
+
+def test_certainty_sampling():
+    """Test the certainty sampling functionality."""
+    test_ids = np.arange(0, 10)
+    queryable_ids = np.array([0, 1, 2, 3, 4, 7, 8, 9])  # No 5 or 6
+    #given that most anomalous = 1.0
+    class1_probs = np.array([
+        0.01,  # 0 - normal
+        0.50,  # 1 - low certainty
+        0.10,  # 2 - pretty normal
+        0.20,  # 3 - pretty normal
+        0.65,  # 4 - low certainty
+        0.79,  # 5 - low certainty (not queryable)
+        0.25,  # 6 - normal
+        0.80,  # 7 - anomalous
+        0.40,  # 8 - low certainty
+        0.02,  # 9 - very normal
+    ])
+    class_probs = np.array([class1_probs, class1_probs]).T
+
+    # Test that we generate the correct number of samples.
+    sample = certainty_sampling(class_probs, test_ids, queryable_ids, batch=3)
+    assert len(sample) == 3
+    assert np.array_equal(sample, [7, 4, 1])
 
 def test_uncertainty_sampling():
     """Test the uncertainity sampling functionality."""


### PR DESCRIPTION
This is a relatively small change, but an important one in order to retrieve data used by the LAISS classifier. 

This is a result of the work that @rknop has done, and summarized in this snippet from Slack: "You need to pass the parameter include_hostinfo (set to 1, or, really, something true) to get this additional information."

However, it is also indicative of a broader concern, that each external feature extractor may need to provide a definition of a specific TOM query that is necessary for that specific feature extractor.