### PR TITLE
MongoDB infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "requests",
     "pooch",
     "platformdirs",
+    "pymongo",
+    "mongomock",
 ]
 
 [project.urls]

--- a/src/resspect/database.py
+++ b/src/resspect/database.py
@@ -365,8 +365,16 @@ class DataBase:
                 print('\n Loaded ', self.test_metadata.shape[0],
                       ' samples! \n')
 
-    def load_features(self, path_to_file: str, feature_extractor: str ='Bazin',
-                      screen=False, survey='DES', sample=None ):
+    def load_features(
+        self,
+        path_to_file: str = None,
+        mongo_query: dict = None,
+        feature_extractor: str ='Bazin',
+        screen=False,
+        survey='DES',
+        sample=None,
+        location="filesystem",
+    ):
         """Load features according to the chosen feature extraction method.
 
         Populates properties: data, features, feature_list, header
@@ -392,7 +400,12 @@ class DataBase:
             else, read independent files for 'train' and 'test'.
             Default is None.
         """
-        features_data = load_external_features(path_to_file, location="filesystem")
+        features_data = load_external_features(
+            filename=path_to_file,
+            mongo_query=mongo_query,
+            feature_extractor=feature_extractor,
+            location=location,
+        )
         if feature_extractor == "photometry":
             self.process_photometry_features(features_data, screen=screen, survey=survey, sample=sample)
         else:

--- a/src/resspect/feature_handling_utils.py
+++ b/src/resspect/feature_handling_utils.py
@@ -2,12 +2,14 @@ import io
 import logging
 import os
 import pandas as pd
-from pymongo.mongo_client import MongoClient
+import pymongo
 
 MONGODB_NAME = "resspect_db_test"
 
 MONGO_COLLECTION_NAMES = {
-    "Bump": "resspect_bump"
+    "Bump": "resspect_bump",
+    "Bazin": "resspect_bazin",
+    "Malanchev": "resspect_malanchev"
 }
 import tarfile
 
@@ -29,11 +31,11 @@ def save_features(
             MONGO_URI = os.environ["MONGO_URI"]
         else:
             raise ValueError("Couldn't find $MONGO_URI in envorinment variables.")
-        client = MongoClient(MONGO_URI)
+        client = pymongo.MongoClient(MONGO_URI)
         db = client[MONGODB_NAME]
         collection = db[MONGO_COLLECTION_NAMES[feature_extractor]]
         data_dicts = [data.loc[i].to_dict() for i in range(len(data))]
-        collection.insert_many(data_dicts)
+        _ = collection.insert_many(data_dicts)
         logging.info(
             "Features have been saved to MongoDB collection: %s",
             MONGO_COLLECTION_NAMES[feature_extractor]
@@ -68,7 +70,7 @@ def load_external_features(
             MONGO_URI = os.environ["MONGO_URI"]
         else:
             raise ValueError("Couldn't find $MONGO_URI in envorinment variables.")
-        client = MongoClient(MONGO_URI)
+        client = pymongo.MongoClient(MONGO_URI)
         db = client[MONGODB_NAME]
         collection = db[MONGO_COLLECTION_NAMES[feature_extractor]]
 

--- a/src/resspect/feature_handling_utils.py
+++ b/src/resspect/feature_handling_utils.py
@@ -25,9 +25,10 @@ def save_features(
         else:
             raise ValueError("filename must be provided if saving to the filesystem.")
     elif location == "mongodb":
-        # temporary local fix obviously
-        with open("/Users/maxwest/homework/mongodb_test.pass") as f:
-            MONGO_URI = f.readline().strip("\n")
+        if "MONGO_URI" in os.environ.keys():
+            MONGO_URI = os.environ["MONGO_URI"]
+        else:
+            raise ValueError("Couldn't find $MONGO_URI in envorinment variables.")
         client = MongoClient(MONGO_URI)
         db = client[MONGODB_NAME]
         collection = db[MONGO_COLLECTION_NAMES[feature_extractor]]
@@ -63,8 +64,10 @@ def load_external_features(
         else:
             raise ValueError("filename must be provided if reading from the filesystem.")
     elif location == "mongodb":
-        with open("/Users/maxwest/homework/mongodb_test.pass") as f:
-            MONGO_URI = f.readline().strip("\n")
+        if "MONGO_URI" in os.environ.keys():
+            MONGO_URI = os.environ["MONGO_URI"]
+        else:
+            raise ValueError("Couldn't find $MONGO_URI in envorinment variables.")
         client = MongoClient(MONGO_URI)
         db = client[MONGODB_NAME]
         collection = db[MONGO_COLLECTION_NAMES[feature_extractor]]

--- a/src/resspect/feature_handling_utils.py
+++ b/src/resspect/feature_handling_utils.py
@@ -1,10 +1,18 @@
 import logging
 import pandas as pd
+from pymongo.mongo_client import MongoClient
+
+MONGODB_NAME = "resspect_db_test"
+
+MONGO_COLLECTION_NAMES = {
+    "Bump": "resspect_bump"
+}
 
 def save_features(
         data: pd.DataFrame,
         location: str = "filesystem",
         filename: str = None,
+        feature_extractor: str = "Malanchev",
 ):
     if location == "filesystem":
         if filename is not None:
@@ -12,5 +20,17 @@ def save_features(
             logging.info("Features have been saved to: %s", filename)
         else:
             raise ValueError("filename must be provided if saving to the filesystem.")
+    elif location == "mongodb":
+        with open("~/homework/mongodb_test.pass") as f:
+            MONGO_URI = f.readline().strip("\n")
+        client = MongoClient(MONGO_URI)
+        db = client[MONGODB_NAME]
+        collection = db[MONGO_COLLECTION_NAMES[feature_extractor]]
+        data_dicts = [data.loc[i].to_dict() for i in range(len(data))]
+        collection.insert_many(data_dicts)
+        logging.info(
+            "Features have been saved to MongoDB collection: %s",
+            MONGO_COLLECTION_NAMES[feature_extractor]
+        )
     else:
-        raise NotImplementedError("Alternative storage method implementation tbd.")
+        raise ValueError("location must either be 'filesystem' or 'location'")

--- a/src/resspect/feature_handling_utils.py
+++ b/src/resspect/feature_handling_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pandas as pd
 from pymongo.mongo_client import MongoClient
 

--- a/src/resspect/feature_handling_utils.py
+++ b/src/resspect/feature_handling_utils.py
@@ -25,7 +25,8 @@ def save_features(
         else:
             raise ValueError("filename must be provided if saving to the filesystem.")
     elif location == "mongodb":
-        with open("~/homework/mongodb_test.pass") as f:
+        # temporary local fix obviously
+        with open("/Users/maxwest/homework/mongodb_test.pass") as f:
             MONGO_URI = f.readline().strip("\n")
         client = MongoClient(MONGO_URI)
         db = client[MONGODB_NAME]
@@ -42,8 +43,10 @@ def save_features(
 def load_external_features(
         filename: str = None,
         location: str = "filesystem",
+        mongo_query: dict = None,
+        feature_extractor: str = "Malanchev",
 ):
-    "Load features from a .csv file."
+    "Load features from a .csv file or download them from a MongoDB instance."
     data = None
     if location == "filesystem":
         if filename is not None:
@@ -59,6 +62,19 @@ def load_external_features(
                     data = pd.read_csv(filename, sep=' ', index_col=False)
         else:
             raise ValueError("filename must be provided if reading from the filesystem.")
+    elif location == "mongodb":
+        with open("/Users/maxwest/homework/mongodb_test.pass") as f:
+            MONGO_URI = f.readline().strip("\n")
+        client = MongoClient(MONGO_URI)
+        db = client[MONGODB_NAME]
+        collection = db[MONGO_COLLECTION_NAMES[feature_extractor]]
+
+        cursor = collection.find(mongo_query)
+        data_dicts = []
+        for element in cursor:
+            data_dicts.append(element)
+        # Potential TODO: drop the MongoDB `_id` column ?
+        data = pd.DataFrame(data_dicts)
     else:
-        raise NotImplementedError("Alternative storage method implementation tbd.")
+        raise ValueError("location must either be 'filesystem' or 'location'")
     return data

--- a/src/resspect/fit_lightcurves.py
+++ b/src/resspect/fit_lightcurves.py
@@ -61,9 +61,13 @@ def _snpcc_sample_fit(
 
 
 def fit_snpcc(
-        path_to_data_dir: str, features_file: str,
-        file_prefix: str = "DES_SN", number_of_processors: int = MAX_NUMBER_OF_PROCESSES,
-        feature_extractor: str = 'Bazin'):
+        path_to_data_dir: str,
+        save_location: str = "filesystem",
+        features_file: str = None,
+        file_prefix: str = "DES_SN",
+        number_of_processors: int = MAX_NUMBER_OF_PROCESSES,
+        feature_extractor: str = 'Bazin'
+    ):
     """
     Perform fit to all objects in the SNPCC data.
 
@@ -102,7 +106,7 @@ def fit_snpcc(
         if 'None' not in light_curve_data.features:
             feature_data.append(light_curve_data.get_features_to_write())
     features_df = pd.DataFrame(feature_data, columns=header)
-    save_features(features_df, location="filesystem", filename=features_file)
+    save_features(features_df, location=save_location, filename=features_file, feature_extractor=feature_extractor)
 
 
 def _plasticc_sample_fit(

--- a/src/resspect/fit_lightcurves.py
+++ b/src/resspect/fit_lightcurves.py
@@ -62,8 +62,8 @@ def _snpcc_sample_fit(
 
 def fit_snpcc(
         path_to_data_dir: str,
-        save_location: str = "filesystem",
         features_file: str = None,
+        save_location: str = "filesystem",
         file_prefix: str = "DES_SN",
         number_of_processors: int = MAX_NUMBER_OF_PROCESSES,
         feature_extractor: str = 'Bazin'
@@ -106,7 +106,12 @@ def fit_snpcc(
         if 'None' not in light_curve_data.features:
             feature_data.append(light_curve_data.get_features_to_write())
     features_df = pd.DataFrame(feature_data, columns=header)
-    save_features(features_df, location=save_location, filename=features_file, feature_extractor=feature_extractor)
+    save_features(
+        features_df,
+        location=save_location,
+        filename=features_file,
+        feature_extractor=feature_extractor
+    )
 
 
 def _plasticc_sample_fit(
@@ -143,10 +148,15 @@ def _plasticc_sample_fit(
     return light_curve_data_copy
 
 
-def fit_plasticc(path_photo_file: str, path_header_file: str,
-                 output_file: str, sample='train',
-                 feature_extractor: str = "Bazin",
-                 number_of_processors: int = MAX_NUMBER_OF_PROCESSES):
+def fit_plasticc(
+    path_photo_file: str,
+    path_header_file: str,
+    output_file: str = None,
+    save_location: str = "filesystem",
+    sample='train',
+    feature_extractor: str = "Bazin",
+    number_of_processors: int = MAX_NUMBER_OF_PROCESSES
+):
     """
     Perform fit to all objects in a given PLAsTiCC data file.
     Parameters
@@ -199,7 +209,12 @@ def fit_plasticc(path_photo_file: str, path_header_file: str,
         if 'None' not in light_curve_data.features:
             feature_data.append(light_curve_data.get_features_to_write())
     features_df = pd.DataFrame(feature_data, header=PLASTICC_RESSPECT_FEATURES_HEADER)
-    save_features(features_df, location="filesystem", filename=output_file)
+    save_features(
+        features_df,
+        location=save_location,
+        filename=output_file,
+        feature_extractor=feature_extractor
+    )
 
 def _TOM_sample_fit(
         obj_dic: dict, feature_extractor: str):
@@ -228,9 +243,13 @@ def _TOM_sample_fit(
     
     return light_curve_data
 
-def fit_TOM(data_dic: dict, output_features_file: str,
-            number_of_processors: int = MAX_NUMBER_OF_PROCESSES,
-            feature_extractor: str = 'Bazin'):
+def fit_TOM(
+    data_dic: dict,
+    output_features_file: str = None,
+    save_location: str = "filesystem",
+    number_of_processors: int = MAX_NUMBER_OF_PROCESSES,
+    feature_extractor: str = 'Bazin'
+):
     """
     Perform fit to all objects from the TOM data.
 
@@ -262,7 +281,12 @@ def fit_TOM(data_dic: dict, output_features_file: str,
         if 'None' not in light_curve_data.features:
             feature_data.append(light_curve_data.get_features_to_write())
     features_df = pd.DataFrame(feature_data, columns=header)
-    save_features(features_df, location="filesystem", filename=output_features_file)
+    save_features(
+        features_df,
+        location=save_location,
+        filename=output_features_file,
+        feature_extractor=feature_extractor
+    )
 
 def _sample_fit(
         obj_dic: dict, feature_extractor: str, filters: list, type: str, one_code: list,
@@ -299,7 +323,8 @@ def _sample_fit(
 
 def fit(
         data_dic: dict,
-        output_features_file: str,
+        output_features_file: str = None,
+        save_location: str = "filesystem",
         number_of_processors: int = MAX_NUMBER_OF_PROCESSES,
         feature_extractor: str = 'Bazin',
         filters: Union[str, List[str]] = 'SNPCC',
@@ -379,7 +404,12 @@ def fit(
                 feature_data.append(light_curve_data.get_features_to_write())
 
     features_df = pd.DataFrame(feature_data, columns=header)
-    save_features(features_df, location="filesystem", filename=output_features_file)
+    save_features(
+        features_df,
+        location=save_location,
+        filename=output_features_file,
+        feature_extractor=feature_extractor,
+    )
 
 def request_TOM_data(url: str = "https://desc-tom-2.lbl.gov", username: str = None, 
                      passwordfile: str = None, password: str = None, detected_since_mjd: float = None, 

--- a/src/resspect/learn_loop.py
+++ b/src/resspect/learn_loop.py
@@ -33,25 +33,33 @@ def load_features(database_class: DataBase, config: LoopConfiguration) -> DataBa
     config: `resspect.loop_configuration.LoopConfiguration`
         The configuration elements of the learn loop.
     """
-    if isinstance(config.path_to_features, str):
-        database_class.load_features(
-            path_to_file=config.path_to_features,
-            feature_extractor=config.features_method,
-            survey=config.survey
-        )
+    if config.path_to_features is not None:
+        if isinstance(config.path_to_features, str):
+            database_class.load_features(
+                path_to_file=config.path_to_features,
+                feature_extractor=config.features_method,
+                survey=config.survey,
+            )
+        else:
+            features_set_names = ['train', 'test', 'validation', 'pool']
+            for sample_name in features_set_names:
+                if sample_name in config.path_to_features.keys():
+                    database_class.load_features(
+                        config.path_to_features[sample_name],
+                        feature_extractor=config.features_method,
+                        survey=config.survey,
+                        sample=sample_name
+                    )
+                else:
+                    logging.warning(f'Path to {sample_name} not given.'
+                                    f' Proceeding without this sample')
     else:
-        features_set_names = ['train', 'test', 'validation', 'pool']
-        for sample_name in features_set_names:
-            if sample_name in config.path_to_features.keys():
-                database_class.load_features(
-                    config.path_to_features[sample_name],
-                    feature_extractor=config.features_method,
-                    survey=config.survey,
-                    sample=sample_name
-                )
-            else:
-                logging.warning(f'Path to {sample_name} not given.'
-                                f' Proceeding without this sample')
+        database_class.load_features(
+            mongo_query=config.features_query,
+            feature_extractor=config.features_method,
+            survey=config.survey,
+            location="mongodb",
+        )
 
     database_class.build_samples(
         initial_training=config.training,

--- a/src/resspect/loop_configuration.py
+++ b/src/resspect/loop_configuration.py
@@ -20,6 +20,9 @@ class LoopConfiguration(BaseConfiguration):
         if dict, keywords should be 'train' and 'test',
         and values must contain the path for separate train
         and test sample files.
+    features_query: dict
+        If a feature query is provided (in MongoDB query format), RESSPECT
+        will attempt to get the information from a provided MongoDB instance.
     output_metrics_file: str
         Full path to output file to store metric values of each loop.
     output_queried_file: str

--- a/src/resspect/loop_configuration.py
+++ b/src/resspect/loop_configuration.py
@@ -94,9 +94,10 @@ class LoopConfiguration(BaseConfiguration):
     """
     nloops: int
     strategy: str
-    path_to_features: str
     output_metrics_file: str
     output_queried_file: str
+    path_to_features: str = None
+    features_query: dict = None
     features_method: str = 'Bazin'
     classifier: str = 'RandomForest'
     training: str = 'original'
@@ -121,16 +122,19 @@ class LoopConfiguration(BaseConfiguration):
 
     def __post_init__(self):
         # file checking
-        if isinstance(self.path_to_features, str):
-            if not path.isfile(self.path_to_features):
-                raise ValueError("`path_to_features` must be an existing file.")
-        elif isinstance(self.path_to_features, dict):
-            for key in self.path_to_features.keys():
-                if not path.isfile(self.path_to_features[key]):
-                    raise ValueError(f"path for '{key}' does not exist.")
+        if self.path_to_features is not None:
+            if isinstance(self.path_to_features, str):
+                if not path.isfile(self.path_to_features):
+                    raise ValueError("`path_to_features` must be an existing file.")
+            elif isinstance(self.path_to_features, dict):
+                for key in self.path_to_features.keys():
+                    if not path.isfile(self.path_to_features[key]):
+                        raise ValueError(f"path for '{key}' does not exist.")
+            else:
+                raise ValueError("`path_to_features` must be a str or dict.")
         else:
-            raise ValueError("`path_to_features` must be a str or dict.")
-
+            if self.features_query is None:
+                raise ValueError("Must provide either features file or MongoDB query.")
         if isinstance(self.pretrained_model_path, str):
             if not path.isfile(self.pretrained_model_path):
                 raise ValueError("`pretrained_model_path` must be an existing file.")

--- a/src/resspect/time_domain_configuration.py
+++ b/src/resspect/time_domain_configuration.py
@@ -17,6 +17,9 @@ class TimeDomainConfiguration(BaseConfiguration):
         Full path to output file to store the queried sample.
     path_to_features_dir: str
         Complete path to directory holding features files for all days.
+    features_query: dict
+        If a feature query is provided (in MongoDB query format), RESSPECT
+        will attempt to get the information from a provided MongoDB instance.
     strategy: str
         Query strategy. Options are (all can be run with budget):
         "UncSampling",
@@ -87,10 +90,11 @@ class TimeDomainConfiguration(BaseConfiguration):
     days: list
     output_metrics_file: str
     output_queried_file: str
-    path_to_features_dir: str
     strategy: str
     fname_pattern: list
     path_to_ini_files: dict
+    path_to_features_dir: str = None
+    features_query: dict = None
     batch: int = 1
     canonical: bool = False
     classifier: str = "RandomForest"
@@ -110,8 +114,12 @@ class TimeDomainConfiguration(BaseConfiguration):
 
     def __post_init__(self):
         # file checking
-        if not path.isdir(self.path_to_features_dir):
-            raise ValueError("`path_to_features` must be an existing directory.")
+        if self.path_to_features_dir is not None:
+            if not path.isdir(self.path_to_features_dir):
+                raise ValueError("`path_to_features` must be an existing directory.")
+        else:
+            if self.features_query is None:
+                raise ValueError("Must provide either features dir or MongoDB query.")
 
         # check strategy
         if self.strategy not in VALID_STRATEGIES:

--- a/src/resspect/time_domain_configuration.py
+++ b/src/resspect/time_domain_configuration.py
@@ -17,9 +17,6 @@ class TimeDomainConfiguration(BaseConfiguration):
         Full path to output file to store the queried sample.
     path_to_features_dir: str
         Complete path to directory holding features files for all days.
-    features_query: dict
-        If a feature query is provided (in MongoDB query format), RESSPECT
-        will attempt to get the information from a provided MongoDB instance.
     strategy: str
         Query strategy. Options are (all can be run with budget):
         "UncSampling",
@@ -93,8 +90,7 @@ class TimeDomainConfiguration(BaseConfiguration):
     strategy: str
     fname_pattern: list
     path_to_ini_files: dict
-    path_to_features_dir: str = None
-    features_query: dict = None
+    path_to_features_dir: str
     batch: int = 1
     canonical: bool = False
     classifier: str = "RandomForest"
@@ -114,12 +110,8 @@ class TimeDomainConfiguration(BaseConfiguration):
 
     def __post_init__(self):
         # file checking
-        if self.path_to_features_dir is not None:
-            if not path.isdir(self.path_to_features_dir):
-                raise ValueError("`path_to_features` must be an existing directory.")
-        else:
-            if self.features_query is None:
-                raise ValueError("Must provide either features dir or MongoDB query.")
+        if not path.isdir(self.path_to_features_dir):
+            raise ValueError("`path_to_features` must be an existing directory.")
 
         # check strategy
         if self.strategy not in VALID_STRATEGIES:

--- a/src/resspect/time_domain_loop.py
+++ b/src/resspect/time_domain_loop.py
@@ -91,7 +91,7 @@ def _load_first_loop_and_full_data(
             file_names_dict=light_curve_file_name,
             config=config,
         )
-    else:
+    elif config.features_query is None:
         first_loop_file_name = {'pool': first_loop_file_name}
         first_loop_data = load_dataset(
             file_names_dict=first_loop_file_name,
@@ -103,6 +103,12 @@ def _load_first_loop_and_full_data(
             config=config,
             samples_list=['train', 'test', 'validation'],
             is_load_build_samples=False,
+        )
+    else:
+        load_dataset(
+            file_names_dict=None,
+            config=config,
+            samples_list=[],
         )
     return first_loop_data, light_curve_data
 

--- a/tests/resspect/test_feature_handling_utils.py
+++ b/tests/resspect/test_feature_handling_utils.py
@@ -51,6 +51,7 @@ def test_save_load_from_mongodb():
             feature_extractor="Malanchev",
         )
 
+        # test getting all data from collection
         test_df = load_external_features(
             mongo_query={},
             location="mongodb",
@@ -59,4 +60,14 @@ def test_save_load_from_mongodb():
 
         assert len(test_df) == 51
         # column number goes up by one when we save to mongo (mongo object id)
+        assert len(test_df.columns) == 58
+
+        # test with actual query
+        test2_df = load_external_features(
+            mongo_query={ "type": "II" },
+            location="mongodb",
+            feature_extractor="Malanchev",
+        )
+
+        assert len(test2_df) == 32
         assert len(test_df.columns) == 58

--- a/tests/resspect/test_feature_handling_utils.py
+++ b/tests/resspect/test_feature_handling_utils.py
@@ -1,0 +1,62 @@
+import mongomock
+import os
+import pandas as pd
+from pathlib import Path
+import tempfile
+from unittest.mock import patch
+
+from resspect.feature_handling_utils import *
+
+_TEST_DATA_DIR = Path(__file__).parent.parent.parent / "data" / "tests"
+_TEST_MONGO_URI = "mongodb+srv://resspect:0000000V@resspectcluster0.agzec.mongodb.net/"
+
+
+def test_save_load_from_filesystem():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        features_path = str(_TEST_DATA_DIR / "test_features.csv")
+
+        df = load_external_features(
+            filename=features_path,
+            location="filesystem",
+            feature_extractor="Malanchev"
+        )
+
+        assert len(df) == 51
+        assert len(df.columns) == 57
+
+        output_path = str(Path(temp_dir) / "test_df.csv")
+
+        save_features(
+            data=df,
+            location="filesystem",
+            filename=output_path,
+            feature_extractor="Malanchev",
+        )
+
+        test_df = pd.read_csv(output_path)
+
+        assert len(test_df) == 51
+        assert len(df.columns) == 57
+
+def test_save_load_from_mongodb():
+    os.environ["MONGO_URI"] = _TEST_MONGO_URI
+    test_features_path = str(_TEST_DATA_DIR / "test_features.csv")
+    df = pd.read_csv(test_features_path)
+
+    client = mongomock.MongoClient()
+    with patch("pymongo.MongoClient.__new__", return_value=client):
+        save_features(
+            data=df,
+            location="mongodb",
+            feature_extractor="Malanchev",
+        )
+
+        test_df = load_external_features(
+            mongo_query={},
+            location="mongodb",
+            feature_extractor="Malanchev",
+        )
+
+        assert len(test_df) == 51
+        # column number goes up by one when we save to mongo (mongo object id)
+        assert len(test_df.columns) == 58


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
This is the code for the underlying infrastructure changes for running RESSPECT with a MongoDB instance. It is fully implemented for all of the feature extraction methods and the learn_loop. 

- For saving to a MongoDB instance, pass in the `save_location` as `"mongodb"` and the extracted features will be saved in their respective MongoDB collections.
- For pulling from MongoDB for `learn_loop`, you can pass in a [pymongo query](https://www.w3schools.com/python/python_mongodb_query.asp) to get the needed information. This could be something like `{ "type": "II", "mjd":  60000 }`. 

These changes build off those pushed in #84 , and work through the `feature_handling_utils` module (which all elements of the code touching features now use). MongoDB usage is purely optional and all of the CSV handling code is still in place and functional.

MongoDB is currently __*not*__ enabled for the `time_domain_loop` function, as it is built to handle data divided up in different files by observation date, and therefore doesn't really lend itself to porting all that code over to single MongoDB calls. A possible workaround to running the `time_domain_loop`with MongoDB would be to do the following:
```python
# queries for type II SNE between mjd ranges 60000 and 60010
query = {
    "type": "II", 
    "mjd": { 
        "$gte" :  60000,
        "$lte" : 60010
    }
}

data_df = load_external_features(
    mongo_query=query,
    location="mongodb",
    feature_extractor="Malanchev",
)

...
# divide up the dataframe into separate files by date
# save those files to csv
# use them as they were previously
```
Otherwise, I think that `time_domain_loop` would need to be fully refactored and probably just done over again to be integrated with MongoDB which is outside of the scope of the incubator.



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
This PR handles all the necessary code changes to have feature extraction and `learn_loop` make calls to an existing MongoDB instance. Since I don't currently have access to the TOM instance, that'll be something y'all will need to do on your own (it shouldn't take that long). What you need to do to get working with MongoDB is:
- Set up the named collections for the various resspect feature extractors
  - "resspect_bump"
  - "resspect_bazin"
  - "resspect_malanchev"
- Get the MongoDB instance [connection string](https://www.mongodb.com/docs/manual/reference/connection-string/)
- Set the `$MONGO_URI` environment variable to be the connection string
  - In a unix runtime environment, export this value to $PATH or add it to the `.bashrc` file
  - In a jupyter notebook, you can `import os` and set `os.environ["MONGO_URI"] = connection_string`

After that, everything should run smoothly between RESSPECT and MongoDB!

Note: you can change which collections the data is added to by changing the `MONGO_COLLECTION_NAMES` dictionary in `feature_handling_utils.py`. If you move away from saving the features based on feature extraction names you could generalize the saving by adding another `collection_name` parameter to `LearnLoopConfiguration` and using that as the key instead `feature_extractor`, but to keep things as clean and backward compatible as possible it currently just uses the feature extractor as the key.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
