### PR TITLE
add support for parquets as an intermediate file format

### DIFF
--- a/src/resspect/feature_handling_utils.py
+++ b/src/resspect/feature_handling_utils.py
@@ -7,11 +7,17 @@ def save_features(
         data: pd.DataFrame,
         location: str = "filesystem",
         filename: str = None,
+        save_format: str = "csv",
 ):
     """Save features from a pandas Dataframe."""
     if location == "filesystem":
         if filename is not None:
-            data.to_csv(filename)
+            if save_format == "csv":
+                data.to_csv(filename)
+            elif save_format == "parquet":
+                data.to_parquet(filename)
+            else:
+                raise ValueError("Unknown filetype for save_format argument.")
             logging.info("Features have been saved to: %s", filename)
         else:
             raise ValueError("filename must be provided if saving to the filesystem.")
@@ -22,7 +28,7 @@ def load_external_features(
         filename: str = None,
         location: str = "filesystem",
 ):
-    "Load features from a .csv file."
+    "Load features from a .csv or .parquet file."
     data = None
     if location == "filesystem":
         if filename is not None:
@@ -31,6 +37,8 @@ def load_external_features(
                     fname = tar.getmembers()[0]
                     content = tar.extractfile(fname).read()
                     data = pd.read_csv(io.BytesIO(content))
+            elif '.parquet' in filename:
+                data = pd.read_parquet(filename)
             else:
                 data = pd.read_csv(filename, index_col=False)
                 if "Unnamed" not in data.keys()[0] and " " in data.keys()[0]:

--- a/src/resspect/fit_lightcurves.py
+++ b/src/resspect/fit_lightcurves.py
@@ -226,7 +226,8 @@ def _TOM_sample_fit(
 
 def fit_TOM(data_dic: dict, output_features_file: str,
             number_of_processors: int = MAX_NUMBER_OF_PROCESSES,
-            feature_extractor: str = 'Bazin'):
+            feature_extractor: str = 'Bazin',
+            save_format: str = 'csv'):
     """
     Perform fit to all objects from the TOM data.
 
@@ -258,7 +259,7 @@ def fit_TOM(data_dic: dict, output_features_file: str,
         if 'None' not in light_curve_data.features:
             feature_data.append(light_curve_data.get_features_to_write())
     features_df = pd.DataFrame(feature_data, columns=header)
-    save_features(features_df, location="filesystem", filename=output_features_file)
+    save_features(features_df, location="filesystem", filename=output_features_file, save_format=save_format)
 
 def _sample_fit(
         obj_dic: dict, feature_extractor: str, filters: list, type: str, one_code: list,
@@ -301,7 +302,8 @@ def fit(
         filters: Union[str, List[str]] = 'SNPCC',
         type: str = 'unspecified',
         one_code: list = [10],
-        additional_info: list = []
+        additional_info: list = [],
+        save_format: str = "csv"
     ):
     """
     Perform fit to all objects from a generalized dataset.
@@ -375,7 +377,7 @@ def fit(
                 feature_data.append(light_curve_data.get_features_to_write())
 
     features_df = pd.DataFrame(feature_data, columns=header)
-    save_features(features_df, location="filesystem", filename=output_features_file)
+    save_features(features_df, location="filesystem", filename=output_features_file, save_format=save_format)
 
 def request_TOM_data(url: str = "https://desc-tom-2.lbl.gov", username: str = None, 
                      passwordfile: str = None, password: str = None, detected_since_mjd: float = None, 

--- a/src/resspect/fit_lightcurves.py
+++ b/src/resspect/fit_lightcurves.py
@@ -351,6 +351,10 @@ def fit(
             'dec'
     """
 
+    # add an error message to make sure that parquet format is not on when using random forest classifier
+    if (feature_extractor == 'Malanchev' or feature_extractor == 'Bazin') and save_format == 'parquet':
+        raise ValueError("Cannot use .parquet file format with random forest classifier!")
+
     # if `filters` is a key in FILTER_SETS, then use the corresponding value
     # otherwise, assume `filters` is a list of filter strings like `['g', 'r']`.
     if isinstance(filters, str) and filters in FILTER_SETS:


### PR DESCRIPTION
Updates:
- Adds an extra input parameter save_format to fit() in fit_lightcurves (used for feature extraction), so that user can choose between .csv and .parquet as intermediate file format (functions that do the file reads/writes were updated in feature_handling_utils).
- Raises an error if the user tries to use .parquet files as a file format while also using a random forest classifier (they would clash).